### PR TITLE
from __future__ import print_function

### DIFF
--- a/scripts/reader/preprocess.py
+++ b/scripts/reader/preprocess.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 """Preprocess the SQuAD dataset for training."""
 
+from __future__ import print_function
 import argparse
 import os
 import sys


### PR DESCRIPTION
Solves an issue with the print('abc', __file=__'xyz') parameter on Python 2...

flake8 testing of https://github.com/facebookresearch/DrQA on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./scripts/reader/preprocess.py:142:43: E999 SyntaxError: invalid syntax
print('Loading dataset %s' % in_file, file=sys.stderr)
                                          ^

1     E999 SyntaxError: invalid syntax
```