### PR TITLE
Visualize non-normalized scores

### DIFF
--- a/drqa/reader/predictor.py
+++ b/drqa/reader/predictor.py
@@ -45,18 +45,20 @@ def tokenize(text):
 class Predictor(object):
     """Load a pretrained DocReader model and predict inputs on the fly."""
 
-    def __init__(self, model=None, tokenizer=None,
+    def __init__(self, model=None, tokenizer=None, normalize=True,
                  embedding_file=None, num_workers=None):
         """
         Args:
-            model: path to saved model file
-            tokenizer: option string to select tokenizer class
+            model: path to saved model file.
+            tokenizer: option string to select tokenizer class.
+            normalize: squash output score to 0-1 probabilities with a softmax.
             embedding_file: if provided, will expand dictionary to use all
               available pretrained vectors in this file.
             num_workers: number of CPU processes to use to preprocess batches.
         """
         logger.info('Initializing model...')
-        self.model = DocReader.load(model or DEFAULTS['model'])
+        self.model = DocReader.load(model or DEFAULTS['model'],
+                                    normalize=normalize)
 
         if embedding_file:
             logger.info('Expanding dictionary...')

--- a/scripts/reader/interactive.py
+++ b/scripts/reader/interactive.py
@@ -38,6 +38,8 @@ parser.add_argument('--no-cuda', action='store_true',
                     help='Use CPU only')
 parser.add_argument('--gpu', type=int, default=-1,
                     help='Specify GPU device id to use')
+parser.add_argument('--no-normalize', action='store_true',
+                    help='Do not softmax normalize output scores.')
 args = parser.parse_args()
 
 args.cuda = not args.no_cuda and torch.cuda.is_available()
@@ -47,7 +49,8 @@ if args.cuda:
 else:
     logger.info('Running on CPU only.')
 
-predictor = Predictor(args.model, args.tokenizer, num_workers=0)
+predictor = Predictor(args.model, args.tokenizer, num_workers=0,
+                      normalize=not args.no_normalize)
 if args.cuda:
     predictor.cuda()
 


### PR DESCRIPTION
In response to #11 

```
[afisch/~/github/DrQA]$ python scripts/reader/interactive.py --no-normalize
08/02/2017 04:12:31 PM: [ Running on CPU only. ]
08/02/2017 04:12:31 PM: [ Initializing model... ]
08/02/2017 04:12:31 PM: [ Loading model /Users/afisch/github/DrQA/data/reader/single.mdl ]
08/02/2017 04:12:32 PM: [ Initializing tokenizer... ]

DrQA Interactive Document Reader Module
>> process(document, question, candidates=None, top_n=1)
>> usage()

>>> process('My name is Adam.', 'What is my name?')
+------+------+---------+
| Rank | Span |  Score  |
+------+------+---------+
|  1   | Adam | 700.247 |
+------+------+---------+
Time: 0.2814
```

```
[afisch/~/github/DrQA]$ python scripts/reader/interactive.py
08/02/2017 04:13:15 PM: [ Running on CPU only. ]
08/02/2017 04:13:15 PM: [ Initializing model... ]
08/02/2017 04:13:15 PM: [ Loading model /Users/afisch/github/DrQA/data/reader/single.mdl ]
08/02/2017 04:13:17 PM: [ Initializing tokenizer... ]

DrQA Interactive Document Reader Module
>> process(document, question, candidates=None, top_n=1)
>> usage()

>>> process('My name is Adam.', 'What is my name?')
+------+------+----------+
| Rank | Span |  Score   |
+------+------+----------+
|  1   | Adam | 0.921679 |
+------+------+----------+
Time: 0.2317
```

