### PR TITLE
Fix PyTorch 0.3.X issues

### DIFF
--- a/drqa/reader/layers.py
+++ b/drqa/reader/layers.py
@@ -206,7 +206,10 @@ class SeqAttnMatch(nn.Module):
         scores.data.masked_fill_(y_mask.data, -float('inf'))
 
         # Normalize with softmax
-        alpha_flat = F.softmax(scores.view(-1, y.size(1)))
+        if torch.__version__ >= '0.3.0':
+            alpha_flat = F.softmax(scores.view(-1, y.size(1)), dim=1)
+        else:
+            alpha_flat = F.softmax(scores.view(-1, y.size(1)))
         alpha = alpha_flat.view(-1, x.size(1), y.size(1))
 
         # Take weighted average
@@ -247,10 +250,16 @@ class BilinearSeqAttn(nn.Module):
         if self.normalize:
             if self.training:
                 # In training we output log-softmax for NLL
-                alpha = F.log_softmax(xWy)
+                if torch.__version__ >= '0.3.0':
+                    alpha = F.log_softmax(xWy, dim=1)
+                else:
+                    alpha = F.log_softmax(xWy)
             else:
                 # ...Otherwise 0-1 probabilities
-                alpha = F.softmax(xWy)
+                if torch.__version__ >= '0.3.0':
+                    alpha = F.softmax(xWy, dim=1)
+                else:
+                    alpha = F.softmax(xWy)
         else:
             alpha = xWy.exp()
         return alpha
@@ -277,7 +286,10 @@ class LinearSeqAttn(nn.Module):
         x_flat = x.view(-1, x.size(-1))
         scores = self.linear(x_flat).view(x.size(0), x.size(1))
         scores.data.masked_fill_(x_mask.data, -float('inf'))
-        alpha = F.softmax(scores)
+        if torch.__version__ >= '0.3.0':
+            alpha = F.softmax(scores, dim=1)
+        else:
+            alpha = F.softmax(scores)
         return alpha
 
 


### PR DESCRIPTION
Fix PyTorch deprecation issues. The code is tested on **PyTorch 0.3.1** in prediction mode, training from scratch and when resuming training from older torch models.

Tested on a custom French dataset (80 epochs) :
[ Num train examples = 210192 ]
[ Num dev examples  = 10570 ]

