### PR TITLE
Fix prediction on CPU in DocReader.

### DIFF
--- a/drqa/reader/model.py
+++ b/drqa/reader/model.py
@@ -283,8 +283,7 @@ class DocReader(object):
             inputs = [e if e is None else e.cuda(non_blocking=True)
                       for e in ex[:5]]
         else:
-            inputs = [e if e is None else e.cuda(non_blocking=True)
-                      for e in ex[:5]]
+            inputs = [e for e in ex[:5]]
 
         # Run forward
         with torch.no_grad():


### PR DESCRIPTION
The prediction using the interactive script failed when running on CPU only:

python3 scripts/pipeline/interactive.py
03/12/2019 08:13:21 AM: [ Running on CPU only. ]
03/12/2019 08:13:21 AM: [ Initializing pipeline... ]
03/12/2019 08:13:21 AM: [ Initializing document ranker... ]
03/12/2019 08:13:21 AM: [ Loading /home/sebastian/DrQA/data/wikipedia/docs-tfidf-ngram=2-hash=16777216-tokenizer=simple.npz ]
03/12/2019 08:14:02 AM: [ Initializing document reader... ]
03/12/2019 08:14:02 AM: [ Loading model /home/sebastian/DrQA/data/reader/multitask.mdl ]
03/12/2019 08:14:03 AM: [ Initializing tokenizers and document retrievers... ]

Interactive DrQA
>> process(question, candidates=None, top_n=1, n_docs=5)
>> usage()

>>> process('What is question answering?')
03/12/2019 08:14:11 AM: [ Processing 1 queries... ]
03/12/2019 08:14:11 AM: [ Retrieving top 5 docs... ]
03/12/2019 08:14:13 AM: [ Reading 106 paragraphs... ]
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "scripts/pipeline/interactive.py", line 81, in process
    question, candidates, top_n, n_docs, return_context=True
  File "/home/sebastian/DrQA/drqa/pipeline/drqa.py", line 190, in process
    top_n, n_docs, return_context
  File "/home/sebastian/DrQA/drqa/pipeline/drqa.py", line 270, in process_batch
    handle = self.reader.predict(batch, async_pool=self.processes)
  File "/home/sebastian/DrQA/drqa/reader/model.py", line 287, in predict
    for e in ex[:5]]
  File "/home/sebastian/DrQA/drqa/reader/model.py", line 287, in <listcomp>
    for e in ex[:5]]
  File "/usr/local/lib/python3.5/dist-packages/torch/cuda/__init__.py", line 161, in _lazy_init
    _check_driver()
  File "/usr/local/lib/python3.5/dist-packages/torch/cuda/__init__.py", line 75, in _check_driver
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled

The code change made here fixes the issue.