### PR TITLE
Update setup.py to fix setup bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 from setuptools import setup, find_packages
 import sys
 
-with open('README.md') as f:
+with open('README.md', encoding='utf-8') as f:
     readme = f.read()
 
 with open('LICENSE') as f:


### PR DESCRIPTION
Seen
```
Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    readme = f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8673: ordinal not in range(128)
```
Change reading readme in setup to explicitly use utf-8 will fix this