### PR TITLE
Update default spaCy model

### DIFF
--- a/drqa/tokenizers/spacy_tokenizer.py
+++ b/drqa/tokenizers/spacy_tokenizer.py
@@ -20,9 +20,9 @@ class SpacyTokenizer(Tokenizer):
         """
         Args:
             annotators: set that can include pos, lemma, and ner.
-            model: spaCy model to use (either path, or keyword like 'en').
+            model: spaCy model to use (either path, or keyword like 'en_core_web_sm').
         """
-        model = kwargs.get('model', 'en')
+        model = kwargs.get('model', 'en_core_web_sm')
         self.annotators = copy.deepcopy(kwargs.get('annotators', set()))
         nlp_kwargs = {'parser': False}
         if not any([p in self.annotators for p in ['lemma', 'pos', 'ner']]):

--- a/drqa/tokenizers/spacy_tokenizer.py
+++ b/drqa/tokenizers/spacy_tokenizer.py
@@ -20,9 +20,9 @@ class SpacyTokenizer(Tokenizer):
         """
         Args:
             annotators: set that can include pos, lemma, and ner.
-            model: spaCy model to use (either path, or keyword like 'en_core_web_sm').
+            model: spaCy model to use (either path, or keyword like 'en_core_web_md').
         """
-        model = kwargs.get('model', 'en_core_web_sm')
+        model = kwargs.get('model', 'en_core_web_md')
         self.annotators = copy.deepcopy(kwargs.get('annotators', set()))
         nlp_kwargs = {'parser': False}
         if not any([p in self.annotators for p in ['lemma', 'pos', 'ner']]):


### PR DESCRIPTION
Currently, the spaCy model defaults to `en`. However, `en` is not an option anymore. Reference: https://spacy.io/models/en

The three English pretrained models are:
* `en_core_web_sm`
* `en_core_web_md`
* `en_core_web_lg`

This PR changes the default to `en_core_web_md` which is the smallest model with GloVe vectors, and has a reasonable download size of 48MB, vs the `lg` model which is 746MB.