### PR TITLE
Adding explicit UTF-8 encoding while reading readme, license and requirements file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@
 from setuptools import setup, find_packages
 import sys
 
-with open('README.md') as f:
+with open('README.md', encoding='utf8') as f:
     readme = f.read()
 
-with open('LICENSE') as f:
+with open('LICENSE', encoding='utf8') as f:
     license = f.read()
 
-with open('requirements.txt') as f:
+with open('requirements.txt', encoding='utf8') as f:
     reqs = f.read()
 
 setup(


### PR DESCRIPTION
Issue: https://github.com/facebookresearch/DrQA/issues/268

Testing:
Issue is seen in Python-3.6.9 and goes away with this fix.
Issue is not seen in Python-3.8.2 and doesn't get impacted by this fix.